### PR TITLE
correct GitHub link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ brew install gumbo-query
 ```
 Through git:
 ```bash
-$ git clone https://github.com/Falven/gumbo-query
+$ git clone https://github.com/lazytiger/gumbo-query
 $ cd gumbo-query/build && cmake .. && make && make test
 $ sudo make install
 ```


### PR DESCRIPTION
The old Github link causes the user to download an old version of gumbo-query. Instead it should match the new repository.
