### PR TITLE
Fixed bugs when mOp is EAdjacent.

### DIFF
--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -106,7 +106,7 @@ CSelector* CParser::parseSelector()
 		}
 		else if (combinator == '~')
 		{
-			ret = new CBinarySelector(oldRet, sel, true);
+			ret = new CBinarySelector(oldRet, sel, false);
 		}
 		else
 		{

--- a/src/Selector.cpp
+++ b/src/Selector.cpp
@@ -242,7 +242,8 @@ bool CBinarySelector::match(GumboNode* apNode)
 				for (long i = pos - 1; i >= 0; i--)
 				{
 					GumboNode* sibling = (GumboNode*) parent->v.element.children.data[i];
-					if (sibling->type == GUMBO_NODE_TEXT || sibling->type == GUMBO_NODE_COMMENT || 
+					if (sibling->type == GUMBO_NODE_TEXT || 
+					    sibling->type == GUMBO_NODE_COMMENT || 
 					    sibling->type == GUMBO_NODE_WHITESPACE)
 					{
 						continue;
@@ -253,7 +254,7 @@ bool CBinarySelector::match(GumboNode* apNode)
 				return false;
 			}
 
-			for (long i = pos; i >= 0; i--)
+			for (long i = pos - 1; i >= 0; i--)
 			{
 				GumboNode* sibling = (GumboNode*) parent->v.element.children.data[i];
 				if (mpS1->match(sibling))

--- a/src/Selector.cpp
+++ b/src/Selector.cpp
@@ -239,10 +239,11 @@ bool CBinarySelector::match(GumboNode* apNode)
 			GumboNode* parent = apNode->parent;
 			if (mAdjacent)
 			{
-				for (long i = pos; i >= 0; i--)
+				for (long i = pos - 1; i >= 0; i--)
 				{
 					GumboNode* sibling = (GumboNode*) parent->v.element.children.data[i];
-					if (sibling->type == GUMBO_NODE_TEXT || sibling->type == GUMBO_NODE_COMMENT)
+					if (sibling->type == GUMBO_NODE_TEXT || sibling->type == GUMBO_NODE_COMMENT || 
+					    sibling->type == GUMBO_NODE_WHITESPACE)
 					{
 						continue;
 					}


### PR DESCRIPTION
* The check loop should begin from pos - 1, this would fix the combinator '+' not working bug.
* mAdjacent should be false, when combinator '~'.